### PR TITLE
Setup very basic CI pipeline using GitHub actions

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -1,0 +1,38 @@
+name: CI GitHub Actions
+
+on:
+  push:
+    branches:
+    - master
+    - dev
+  pull_request:
+    branches:
+    - master
+    - dev
+  schedule:
+    - cron:  '* * * * 1'
+
+jobs:
+  build-windows:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-2016, windows-2019]
+      fail-fast: false
+
+    steps:
+    - uses: actions/checkout@v1
+    
+    - name: Setup MSBuild.exe
+      uses: warrenbuckley/Setup-MSBuild@v1
+      
+    - name: Setup Nuget.exe
+      uses: warrenbuckley/Setup-Nuget@v1
+      
+    - name: Restore Nuget packages
+      run: nuget restore
+      
+    - name: Build and publish project
+      working-directory: easyPokerHUD
+      run: msbuild easyPokerHUD.csproj /t:Clean;Restore;Build;Publish /p:Configuration=Release

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -10,7 +10,7 @@ on:
     - master
     - dev
   schedule:
-    - cron:  '* * * * 1'
+    - cron:  '1 0 * * 1'
 
 jobs:
   build-windows:


### PR DESCRIPTION
Very basic CI that ensures the project's compilation and publish process isn't broken.
It will run in every pull request against `dev` and `master` (now it's up to you to make in the repository configuration passing those checks compulsory or not) and periodically at 00:01 every Monday.

Here you have an [example of the compilation working](https://github.com/eduherminio/easyPokerHUD/pull/1).